### PR TITLE
Adding support for header['alg'] = 'dir'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "jcwatson11/jose",
+  "name": "gree/jose",
   "version": "2.0.0",
   "description": "JWT, JWS and JWS implementation in PHP",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "gree/jose",
+  "name": "jcwatson11/jose",
   "version": "2.0.0",
   "description": "JWT, JWS and JWS implementation in PHP",
   "keywords": [

--- a/example/IdToken.php
+++ b/example/IdToken.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname(__FILE__) . '/../src/JOSE/JWT.php';
+
 // an example of OpenID Connect ID Token implementation
 
 class IdToken {

--- a/src/JOSE/Exception.php
+++ b/src/JOSE/Exception.php
@@ -2,3 +2,8 @@
 
 class JOSE_Exception extends Exception {
 }
+
+require_once dirname(__FILE__) . '/Exception/DecryptionFailed.php';
+require_once dirname(__FILE__) . '/Exception/InvalidFormat.php';
+require_once dirname(__FILE__) . '/Exception/UnexpectedAlgorithm.php';
+require_once dirname(__FILE__) . '/Exception/VerificationFailed.php';

--- a/src/JOSE/JWE.php
+++ b/src/JOSE/JWE.php
@@ -4,6 +4,8 @@ use phpseclib\Crypt\RSA;
 use phpseclib\Crypt\AES;
 use phpseclib\Crypt\Random;
 
+require_once dirname(__FILE__) . '/JWT.php';
+
 class JOSE_JWE extends JOSE_JWT {
     var $plain_text;
     var $cipher_text;
@@ -154,6 +156,10 @@ class JOSE_JWE extends JOSE_JWT {
 
     private function decryptContentEncryptionKey($public_or_private_key) {
         switch ($this->header['alg']) {
+            case 'dir':
+                $tmpkey = base64_decode($public_or_private_key);
+                $this->content_encryption_key = $tmpkey;
+                break;
             case 'RSA1_5':
                 $rsa = $this->rsa($public_or_private_key, RSA::ENCRYPTION_PKCS1);
                 $this->content_encryption_key = $rsa->decrypt($this->jwe_encrypted_key);
@@ -164,7 +170,6 @@ class JOSE_JWE extends JOSE_JWT {
                 break;
             case 'A128KW':
             case 'A256KW':
-            case 'dir':
             case 'ECDH-ES':
             case 'ECDH-ES+A128KW':
             case 'ECDH-ES+A256KW':

--- a/src/JOSE/JWS.php
+++ b/src/JOSE/JWS.php
@@ -2,6 +2,8 @@
 
 use phpseclib\Crypt\RSA;
 
+require_once dirname(__FILE__) . '/JWT.php';
+
 class JOSE_JWS extends JOSE_JWT {
     function __construct($jwt) {
         $this->header = $jwt->header;
@@ -114,11 +116,13 @@ class JOSE_JWS extends JOSE_JWT {
     private function _verify($public_key_or_secret, $expected_alg = null) {
         $segments = explode('.', $this->raw);
         $signature_base_string = implode('.', array($segments[0], $segments[1]));
-        if (!$expected_alg) {
+        if (!$expected_alg && $this->header['alg'] != 'dir') {
             # NOTE: might better to warn here
             $expected_alg = $this->header['alg'];
         }
         switch ($expected_alg) {
+            case 'dir':
+                return $this->header['alg'] == $expected_alg;
             case 'HS256':
             case 'HS384':
             case 'HS512':

--- a/src/JOSE/JWT.php
+++ b/src/JOSE/JWT.php
@@ -1,5 +1,12 @@
 <?php
 
+require_once dirname(__FILE__) . '/Exception.php';
+require_once dirname(__FILE__) . '/JWS.php';
+require_once dirname(__FILE__) . '/JWE.php';
+require_once dirname(__FILE__) . '/JWK.php';
+require_once dirname(__FILE__) . '/JWKSet.php';
+require_once dirname(__FILE__) . '/URLSafeBase64.php';
+
 class JOSE_JWT {
     var $header = array(
         'typ' => 'JWT',

--- a/test/JOSE/TestCase.php
+++ b/test/JOSE/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname(__FILE__) . '/../../src/JOSE/JWT.php';
+
 abstract class JOSE_TestCase extends PHPUnit_Framework_TestCase {
     var $fixture_dir;
     var $rsa_keys;


### PR DESCRIPTION
This commit was created off of the 2.0.0 tag of nov/jose-php. It appears that there are changes in 2.0.0 that were not committed to master. The require statements in this commit are in 2.0.0, but not in master. So this pull request shows those changes even though I didn't make them.

Regarding the change, this pull request adds support for alg = 'dir' (Direct Key), meaning a shared key that is not encrypted is used for the decryption, instead of using a public and private key set.

This pull request should be considered a work in progress that I need some help with. Here's where I'm stuck. I'm not an expert in this stuff.

I am able to get the decryption to run with type 'dir' without errors, however, it gives me an empty claims section in the output.

Would you review the code and provide some feedback on whether I'm on the right track or if I missed something?

Thanks!