### PR TITLE
Moved the RSA signing throw into the signing function

### DIFF
--- a/src/JOSE/JWS.php
+++ b/src/JOSE/JWS.php
@@ -66,25 +66,33 @@ class JOSE_JWS extends JOSE_JWT {
     }
 
     private function digest() {
+        $digest = '';
         switch ($this->header['alg']) {
             case 'HS256':
             case 'RS256':
             case 'ES256':
             case 'PS256':
-                return 'sha256';
+                $digest =  'sha256';
+                break;
             case 'HS384':
             case 'RS384':
             case 'ES384':
             case 'PS384':
-                return 'sha384';
+                $digest = 'sha384';
+                break;
             case 'HS512':
             case 'RS512':
             case 'ES512':
             case 'PS512':
-                return 'sha512';
+                $digest = 'sha512';
+                break;
             default:
                 throw new JOSE_Exception_UnexpectedAlgorithm('Unknown algorithm');
         }
+        if(!in_array($digest, hash_algos())) {
+            throw new JOSE_Exception_UnexpectedAlgorithm(sprintf('Hashing algorithm %s does not exist', $this->header['alg']));
+        }
+        return $digest;
     }
 
     private function _sign($private_key_or_secret) {
@@ -92,6 +100,7 @@ class JOSE_JWS extends JOSE_JWT {
             $this->compact((object) $this->header),
             $this->compact((object) $this->claims)
         ));
+
         switch ($this->header['alg']) {
             case 'HS256':
             case 'HS384':

--- a/src/JOSE/JWS.php
+++ b/src/JOSE/JWS.php
@@ -39,9 +39,6 @@ class JOSE_JWS extends JOSE_JWT {
             $this->header['kid'] = $private_key_or_secret->components['kid'];
         }
         $this->signature = $this->_sign($private_key_or_secret);
-        if (!$this->signature) {
-            throw new JOSE_Exception('Signing failed because of unknown reason');
-        }
         return $this;
     }
 
@@ -103,7 +100,11 @@ class JOSE_JWS extends JOSE_JWT {
             case 'RS256':
             case 'RS384':
             case 'RS512':
-                return $this->rsa($private_key_or_secret, RSA::SIGNATURE_PKCS1)->sign($signature_base_string);
+                $hash = $this->rsa($private_key_or_secret, RSA::SIGNATURE_PKCS1)->sign($signature_base_string);
+                if (!$hash) {
+                    throw new JOSE_Exception('RSA signing failed because of unknown reason');
+                }
+                return $hash;
             case 'ES256':
             case 'ES384':
             case 'ES512':

--- a/test/JOSE/JWS_Test.php
+++ b/test/JOSE/JWS_Test.php
@@ -28,6 +28,12 @@ class JOSE_JWS_Test extends JOSE_TestCase {
         $this->assertEquals($expected, sprintf('%s', $jws->toJSON('general-syntax')));
     }
 
+    function testSignBadAlgorithm() {
+        $jws = new JOSE_JWS($this->plain_jwt);
+        $this->setExpectedException('JOSE_Exception_UnexpectedAlgorithm');
+        $jws = $jws->sign('shared-secret', 'blah');
+    }
+
     function testSignHS256() {
         $expected = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIifQ.jBKXM6zRu0nP2tYgNTgFxRDwKoiEbNl1P6GyXEHIwEw';
         $jws = new JOSE_JWS($this->plain_jwt);


### PR DESCRIPTION
Throwing should be inside this private function for proper separation of concerns.

hash_hmac returns false when the algorithm does not exist, but it is not checked.  Added checking and a test.  They recently did remove non-cryptographic algorithms, so it might be a good idea to check.

The hash_algos function isn't sufficient, though.  Working on a patch for php_src.