### PR TITLE
Pass correct mode string to phpseclib

### DIFF
--- a/src/JOSE/JWE.php
+++ b/src/JOSE/JWE.php
@@ -82,7 +82,7 @@ class JOSE_JWE extends JOSE_JWT {
                 throw new JOSE_Exception_UnexpectedAlgorithm('Algorithm not supported');
             case 'A128CBC-HS256':
             case 'A256CBC-HS512':
-                $cipher = new AES(AES::MODE_CBC);
+                $cipher = new AES(self::MODE_CBC);
                 break;
             default:
                 throw new JOSE_Exception_UnexpectedAlgorithm('Unknown algorithm');
@@ -90,7 +90,7 @@ class JOSE_JWE extends JOSE_JWT {
         switch ($this->header['enc']) {
             case 'A128GCM':
             case 'A128CBC-HS256':
-                $cipher->setBlockLength(128);
+                //$cipher->setBlockLength(128);
                 break;
             case 'A256GCM':
             case 'A256CBC-HS512':

--- a/src/JOSE/JWT.php
+++ b/src/JOSE/JWT.php
@@ -1,6 +1,15 @@
 <?php
 
 class JOSE_JWT {
+    const MODE_CTR = 'ctr';
+    const MODE_ECB = 'ecb';
+    const MODE_CBC = 'cbc';
+    const MODE_CFB = 'cfb';
+    const MODE_CFB8 = 'cfb8';
+    const MODE_OFB = 'ofb';
+    const MODE_OFB8 = 'ofb8';
+    const MODE_GCM = 'gcm';
+    const MODE_STREAM = 'stream';
     var $header = array(
         'typ' => 'JWT',
         'alg' => 'none'


### PR DESCRIPTION
- In the current process in cipher() method in JWE.php its `$cipher = new AES(AES::MODE_CBC);`  where AES::MODE_CBC will be '2'.
- and according to the SymmetricKey.php constructor code shown below expects $mode to be a string. As the current code is passing 2, it endsup throw new BadModeException('No valid mode has been specified');

$mode = strtolower($mode);
        // necessary because of 5.6 compatibility; we can't do isset(self::MODE_MAP[$mode]) in 5.6
        $map = self::MODE_MAP;
        if (!isset($map[$mode])) {
            throw new BadModeException('No valid mode has been specified');
        }
